### PR TITLE
Bump indexmap version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming::http-server"]
 
 [dependencies]
 heck = "0.4.0"
-indexmap = "1.6"
+indexmap = "1.8"
 openapiv3 = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
For compatibility with the latest Dropshot and Omicron:

```
error: failed to select a version for `indexmap`.
    ... required by package `openapi-lint v0.2.0 (https://github.com/oxidecomputer/openapi-lint?branch=main#9b20f893)`
    ... which satisfies git dependency `openapi-lint` (locked to 0.2.0) of package `internal-dns v0.1.0 (/home/alex/oxide/omicron/internal-dns)`
versions that meet the requirements `^1.6` (locked to 1.8.1) are: 1.8.1

all possible versions conflict with previously selected packages.

  previously selected package `indexmap v1.8.2`
    ... which satisfies dependency `indexmap = "^1.8.2"` of package `dropshot v0.7.1-dev (/home/alex/oxide/dropshot/dropshot)`
    ... which satisfies git dependency `dropshot` (locked to 0.7.1-dev) of package `internal-dns v0.1.0 (/home/alex/oxide/omicron/internal-dns)`

failed to select a version for `indexmap` which could resolve this conflict
```