### PR TITLE
Allow `not` subschemas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["web-programming::http-server"]
 heck = "0.4.0"
 indexmap = "2.0.0"
 lazy_static = "1.4.0"
-openapiv3 = "2.0.0-rc.1"
+openapiv3 = "2.0.0"
 regex = "1.7.3"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,9 @@ impl Validator {
                     self.subschemas(spec, subschema.item(&spec.components).unwrap())
                 })
                 .collect(),
-            openapiv3::SchemaKind::Not { .. } => todo!("'not' subschemas aren't handled"),
+            openapiv3::SchemaKind::Not { not } => {
+                self.subschemas(spec, not.item(&spec.components).unwrap())
+            }
             openapiv3::SchemaKind::Type(t) => vec![t],
             openapiv3::SchemaKind::Any(any) if is_permissive(any) => vec![],
             openapiv3::SchemaKind::Any(any) => todo!("complex 'any' schema not handled {:#?}", any),

--- a/src/tests/errors.json
+++ b/src/tests/errors.json
@@ -1802,6 +1802,14 @@
         "required": [
           "my_uuid"
         ]
+      },
+      "Marker": {
+        "not": {},
+        "x-rust-type": {
+          "crate": "my-crate",
+          "path": "my_crate::types::MyKind",
+          "version": "1.0.0"
+        }
       }
     }
   }


### PR DESCRIPTION
Initiailly we didn't handle `not` constructions... mostly because we weren't sure about how they might come up, but also because we didn't have experience knowing how to interpret their meaning. Now they are coming up **and** we understand them well enough to treat them like other subschemas (i.e. "anyOf", "oneOf", "allOf").